### PR TITLE
Hotfix: Support non UTF-8 encoded emails

### DIFF
--- a/invoice/collector/collector.py
+++ b/invoice/collector/collector.py
@@ -71,7 +71,7 @@ class AttachmentCollector:
             rawEmail = data[0][1]
 
             # converts byte literal to string removing b''
-            rawEmailString = rawEmail.decode('utf-8')
+            rawEmailString = rawEmail.decode('utf-8', 'ignore')
             emailMessage = email.message_from_string(rawEmailString)
 
             # If subjectFilter is empty or subjectFilter contains a word in email subject


### PR DESCRIPTION
Script crashes when latin1 encoded emails are encountered. (e.g. äöüß)
Added 'ignore' flag to the decoding step.